### PR TITLE
Two ways to supply client id.

### DIFF
--- a/bin/twitch-chatlog
+++ b/bin/twitch-chatlog
@@ -1,17 +1,27 @@
 #! /usr/bin/env node
 
-const argv = require("yargs").usage("Fetch the chat log to a twitch VOD.\nUsage: $0 <vod_id>[ -c]\n\nvod_id is the ID from the VOD URL, prefixed with v.")
-    .string("_")
+const argv = require('yargs').usage('Fetch the chat log to a twitch VOD.\nUsage: $0 <vod_id>[ -c]\n\nvod_id is the ID from the VOD URL, prefixed with v.')
+    .string('_')
     .demand(1)
-    .boolean("c")
-    .describe('c', 'Colorize output')
+    .option('c', {
+        alias: 'color',
+        default: false,
+        describe: 'Colorize output',
+        type: 'boolean'
+    })
+    .option('C', {
+        alias: 'client-id',
+        default: '',
+        describe: 'twitch application client ID',
+        type: 'string'
+    })
     .help('h')
     .alias('h', 'help')
     .version()
-    .example("twitch-chatlog v79240813")
+    .example('twitch-chatlog v79240813')
     .argv;
 
-require("../lib/index.js").getChatlog(argv._[0], argv.c).then(console.log).catch((e) => {
+require('../lib/index.js').getChatlog(argv._[0], argv).then(console.log).catch((e) => {
     console.error(e);
     process.exit(1);
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 const fetch = require("node-fetch");
 const colors = require("colors");
 const toColors = require("hex-to-color-name");
+var headers = {}
 
 function colorize(string, hexColor) {
     return string[toColors(hexColor||"#FFFF00", {
@@ -16,12 +17,13 @@ function colorize(string, hexColor) {
     })];
 }
 
+function _fetch(url) {
+  return fetch(url, {headers: headers})
+}
+
 function getVODMeta(vodID) {
-    return fetch("https://api.twitch.tv/kraken/videos/"+vodID, {
-        headers: {
-            "Client-ID": "hdaoisxhhrc9h3lz3k224iao13crkkq8"
-        }
-    }).then((resp) => {
+    return _fetch("https://api.twitch.tv/kraken/videos/"+vodID)
+    .then((resp) => {
         if(resp.ok)
             return resp.json();
         else
@@ -35,7 +37,7 @@ function getVODMeta(vodID) {
 }
 
 function getChatFragment(start, vodID) {
-    return fetch("https://rechat.twitch.tv/rechat-messages?start="+start+"&video_id="+vodID)
+    return _fetch("https://rechat.twitch.tv/rechat-messages?start="+start+"&video_id="+vodID)
     .then((resp) => {
         if(resp.ok)
             return resp.json();
@@ -76,7 +78,11 @@ function printResults(results, c) {
     }).join("\n");
 }
 
-function searchVOD(vodID, c) {
+function searchVOD(vodID, args) {
+    headers = {
+        "Client-ID": process.env['TWITCH_CLIENT_ID'] || args.clientId
+    }
+
     if(vodID.search(/^v[0-9]+$/) == -1) {
         return Promise.reject("Invalid VOD ID specified. The ID must have the format of v123456789.");
     }
@@ -84,7 +90,7 @@ function searchVOD(vodID, c) {
         return getVODMeta(vodID).then((meta) => {
             return searchChat(meta.start, meta.length, vodID)
         }).then((results) => {
-            return printResults(results, c);
+            return printResults(results, args.color);
         })
     }
 }


### PR DESCRIPTION
Added `-C,--client-id` option to supply twitch application client ID on demand.

Environment variable `TWITCH_CLIENT_ID` can also set the client ID, and takes precedence.
Added long alias `--color` for the color option.

I'd also pulled your current client ID from the code. IMO, it should be regenerated on the twitch side and kept secret.