### PR TITLE
Two ways to supply client ID.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # twitch-chatlog
 Fetch the chatlog to a twitch VOD from your command line with `twitch-chatlog`.
 
-This little command can download the whole chat log to a twitch VOD. It takes the ID of the VOD (v1111111 or similar) as only argument. The output can optionally be colored with `-c`. To learn about the usage of the command, use `twitch-chatlog -h`.
+This little command can download the whole chat log to a twitch VOD. It takes the ID of the VOD (v1111111 or similar) as only argument. To learn about the usage of the command, use `twitch-chatlog -h`.
+
+The output can optionally be colored with `-c` or `--color` or by setting an environment variable `TWITCH_CHATLOG_COLOR`.
+
+To make use of your own Twitch application client ID, you may provide it as a command line option `-C` or `--client-id` or set an environment variable `TWITCH_CHATLOG_CLIENT_ID`. The default value for client ID is not guaranteed to work [past 08 Aug 2016](https://discuss.dev.twitch.tv/t/client-id-requirement-faqs/6108?u=proto_baggins), in which case you will have to supply your own.
 
 ## Installation
 ```
@@ -16,11 +20,12 @@ Usage: twitch-chatlog <vod_id>[ -c]
 vod_id is the ID from the VOD URL, prefixed with v.
 
 Options:
-  -c          Colorize output
-  -h, --help  Show help                                                [boolean]
-  --version   Show version number                                      [boolean]
+  -c, --color      Colorize output                    [boolean] [default: false]
+  -C, --client-id  Twitch application client ID
+                          [string] [default: "hdaoisxhhrc9h3lz3k224iao13crkkq8"]
+  -h, --help       Show help                                           [boolean]
+  --version        Show version number                                 [boolean]
 
 Examples:
   twitch-chatlog v79240813
 ```
-

--- a/bin/twitch-chatlog
+++ b/bin/twitch-chatlog
@@ -3,15 +3,26 @@
 const argv = require("yargs").usage("Fetch the chat log to a twitch VOD.\nUsage: $0 <vod_id>[ -c]\n\nvod_id is the ID from the VOD URL, prefixed with v.")
     .string("_")
     .demand(1)
-    .boolean("c")
-    .describe('c', 'Colorize output')
+    .env('TWITCH_CHATLOG')
+    .option('c', {
+        alias: 'color',
+        default: false,
+        describe: 'Colorize output',
+        type: 'boolean'
+    })
+    .option('C', {
+        alias: 'client-id',
+        default: 'hdaoisxhhrc9h3lz3k224iao13crkkq8',
+        describe: 'Twitch application client ID',
+        type: 'string'
+    })
     .help('h')
     .alias('h', 'help')
     .version()
     .example("twitch-chatlog v79240813")
     .argv;
 
-require("../lib/index.js").getChatlog(argv._[0], argv.c).then(console.log).catch((e) => {
+require("../lib/index.js").getChatlog(argv._[0], argv.color, argv.clientId).then(console.log).catch((e) => {
     console.error(e);
     process.exit(1);
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,10 +16,10 @@ function colorize(string, hexColor) {
     })];
 }
 
-function getVODMeta(vodID) {
+function getVODMeta(vodID, clientId) {
     return fetch("https://api.twitch.tv/kraken/videos/"+vodID, {
         headers: {
-            "Client-ID": "hdaoisxhhrc9h3lz3k224iao13crkkq8"
+            "Client-ID": clientId
         }
     }).then((resp) => {
         if(resp.ok)
@@ -76,15 +76,15 @@ function printResults(results, c) {
     }).join("\n");
 }
 
-function searchVOD(vodID, c) {
+function searchVOD(vodID, colorize, clientId) {
     if(vodID.search(/^v[0-9]+$/) == -1) {
         return Promise.reject("Invalid VOD ID specified. The ID must have the format of v123456789.");
     }
     else {
-        return getVODMeta(vodID).then((meta) => {
+        return getVODMeta(vodID, clientId).then((meta) => {
             return searchChat(meta.start, meta.length, vodID)
         }).then((results) => {
-            return printResults(results, c);
+            return printResults(results, colorize);
         })
     }
 }


### PR DESCRIPTION
This PR replaces MR #1 , being a distilled version based on the conversation about the changes.

Added -C,--client-id option to supply twitch application client ID on demand.

Environment variable TWITCH_CHATLOG_CLIENT_ID can also set the client ID, and takes precedence.
Added long alias --color for the color option.