### PR TITLE
Serialized requests to twitch server

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ const fetch = require("node-fetch");
 const colors = require("colors");
 const toColors = require("hex-to-color-name");
 const ProgressBar = require("progress");
+const Promise = require("bluebird");
 
 function colorize(string, hexColor) {
     return string[toColors(hexColor||"#FFFF00", {
@@ -66,9 +67,9 @@ function searchChat(start, length, vodID, c = false, progress = false, testServe
         ts.push(start+i);
     }
 
-	var promises = ts.map((timestamp) => {
+    var promises = Promise.map(ts, (timestamp) => {
         return getChatFragment(timestamp, vodID, testServer);
-    });
+    }, {concurrency: 1})
 
     var bar = false;
     /* istanbul ignore next */

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "author": "Martin Giger (https://humanoids.be)",
   "license": "MIT",
   "dependencies": {
+    "bluebird": "^3.4.1",
     "colors": "^1.1.2",
     "hex-to-color-name": "^1.0.1",
     "node-fetch": "^1.5.3",


### PR DESCRIPTION
Serialized the requests to the twitch servers. Previously it was opening a large number of simultaneous connections, one for each 30s of vod length. It was probably a bit harsh on twitch before and would lead to timeouts.  