### PR TITLE
Fix getaddrinfo ENOTFOUND and switch from fetch to request-promise

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,7 @@ function getHost(host, testServer) {
 
 function getVODMeta(vodID, clientId, testServer) {
     var options = {
-      url: getHost("https://api.twitch.tv", testServer)+"/kraken/videos/"+vodID,
+      url: getHost("https://api.twitch.tv", testServer)+"/kraken/videos/v"+vodID,
       headers: {
           "Client-ID": clientId,
           "Accept": "application/vnd.twitchtv.v3+json"
@@ -49,7 +49,7 @@ function getVODMeta(vodID, clientId, testServer) {
 
 function getChatFragment(start, vodID, testServer) {
   var options = {
-    url: getHost("https://rechat.twitch.tv", testServer)+"/rechat-messages?start="+start+"&video_id="+vodID,
+    url: getHost("https://rechat.twitch.tv", testServer)+"/rechat-messages?start="+start+"&video_id=v"+vodID,
     family: 4, // https://github.com/nodejs/node/issues/5436#issuecomment-189600282
   };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
-const fetch = require("node-fetch"),
-    colors = require("colors"),
+const colors = require("colors"),
     toColors = require("hex-to-color-name"),
-    ProgressBar = require("progress");
+    ProgressBar = require("progress"),
+    requestpromise = require('request-promise');
 
 function colorize(string, hexColor) {
     return string[toColors(hexColor||"#FFFF00", {
@@ -28,36 +28,34 @@ function getHost(host, testServer) {
 }
 
 function getVODMeta(vodID, clientId, testServer) {
-    return fetch(getHost("https://api.twitch.tv", testServer)+"/kraken/videos/"+vodID, {
-        headers: {
-            "Client-ID": clientId,
-            "Accept": "application/vnd.twitchtv.v5+json"
-        }
-    }).then((resp) => {
-        if(resp.ok)
-            return resp.json();
-        else
-            throw "Could not load VOD details: " + resp.statusText;
-    }).then((json) => {
-        return {
-            start: Date.parse(json.recorded_at),
-            length: json.length
-        };
+    var options = {
+      url: getHost("https://api.twitch.tv", testServer)+"/kraken/videos/"+vodID,
+      headers: {
+          "Client-ID": clientId,
+          "Accept": "application/vnd.twitchtv.v3+json"
+      },
+      family: 4, // https://github.com/nodejs/node/issues/5436#issuecomment-189600282
+    };
+
+    return requestpromise(options).then((resp) => {
+      var json = JSON.parse(resp);
+
+      return {
+          start: Date.parse(json.recorded_at),
+          length: json.length
+      };
     });
 }
 
 function getChatFragment(start, vodID, testServer) {
-    return fetch(getHost("https://rechat.twitch.tv", testServer)+"/rechat-messages?start="+start+"&video_id="+vodID)
-    .then((resp) => {
-        if(resp.ok) {
-            return resp.json();
-        }
-        else {
-            throw "Could not load fragment at "+start+": "+resp.statusText;
-        }
-    }).then((json) => {
-        return json.data;
-    });
+  var options = {
+    url: getHost("https://rechat.twitch.tv", testServer)+"/rechat-messages?start="+start+"&video_id="+vodID,
+    family: 4, // https://github.com/nodejs/node/issues/5436#issuecomment-189600282
+  };
+
+  return requestpromise(options).then((resp) => {
+      return JSON.parse(resp).data;
+  });
 }
 
 function searchChat(start, length, vodID, c = false, progress = false, workerCount = 1, testServer) {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
   "dependencies": {
     "colors": "^1.1.2",
     "hex-to-color-name": "^1.0.1",
-    "node-fetch": "^1.5.3",
     "progress": "^2.0.0",
+    "request": "^2.81.0",
+    "request-promise": "^4.2.1",
     "yargs": "^8.0.1"
   },
   "repository": {


### PR DESCRIPTION
Testing on mac, node-fetch would throw errors trying to use from both the command line or a node script including with require('twitch-chatlog')

With these changes, it will properly get through. Seems like an IPv4/IPv6 issue