### PR TITLE
Fix vodId, getaddrinfo ENOTFOUND, and switch from fetch to request-promise

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,30 +34,29 @@ function getVODMeta(vodID, clientId, testServer) {
           "Client-ID": clientId,
           "Accept": "application/vnd.twitchtv.v3+json"
       },
+      timeout: 1000*60,
+      json: true,
       family: 4, // https://github.com/nodejs/node/issues/5436#issuecomment-189600282
     };
 
-    return requestpromise(options).then((resp) => {
-      var json = JSON.parse(resp);
-
-      return {
-          start: Date.parse(json.recorded_at),
-          length: json.length
-      };
-    });
+    return requestpromise(options);
 }
 
 exports.getVODMeta = getVODMeta;
 
+// https://discuss.dev.twitch.tv/t/getting-chat-replay-transcript/5295
+// Each msg timestamp appears delayed ~14 seconds likely to be account for HLS delay
 function getChatFragment(start, vodID, testServer) {
   var options = {
     url: getHost("https://rechat.twitch.tv", testServer)+"/rechat-messages?start="+start+"&video_id=v"+vodID,
+    timeout: 1000*60,
+    json: true,
     family: 4, // https://github.com/nodejs/node/issues/5436#issuecomment-189600282
   };
 
-  return requestpromise(options).then((resp) => {
-      return JSON.parse(resp).data;
-  });
+  return {
+    then: (callback) => { return requestpromise(options).then((jsonObj) => jsonObj.data).then(callback); },
+  };
 }
 
 function searchChat(start, length, vodID, c = false, progress = false, workerCount = 1, testServer) {
@@ -91,16 +90,18 @@ function searchChat(start, length, vodID, c = false, progress = false, workerCou
             bar.tick();
             return result;
         };
-        promises = promises.map((p) => p.then(progressListener));
-	}
+        promises = promises.map((p) => {
+          return {then: () => { return p.then(progressListener); } };
+        });
+	   }
 
     // Parallel promise fetching.
 	const workerHandler = (prevResult, result) => {
-            let ret = Array.isArray(result) ? result : [ result ];
-            if(prevResult) {
-                ret = ret.concat(prevResult);
-            }
-            return ret;
+      let ret = Array.isArray(result) ? result : [ result ];
+      if(prevResult) {
+          ret = ret.concat(prevResult);
+      }
+      return ret;
         },
         worker = (prevResult) => {
             const promise = promises.shift();
@@ -212,7 +213,12 @@ function searchVOD(options) {
         options.length = Number.MAX_SAFE_INTEGER;
     }
 
-    return getVODMeta(options.vodId, options.clientId, options.testServer).then((meta) => {
+    return getVODMeta(options.vodId, options.clientId, options.testServer).then((json) => {
+        var meta = {
+            start: Date.parse(json.recorded_at),
+            length: json.length
+        };
+
         var diff, start;
         if(meta.start > options.start) {
             start = meta.start + options.start;

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,7 @@ function getHost(host, testServer) {
 
 function getVODMeta(vodID, clientId, testServer) {
     var options = {
-      url: getHost("https://api.twitch.tv", testServer)+"/kraken/videos/"+vodID,
+      url: getHost("https://api.twitch.tv", testServer)+"/kraken/videos/v"+vodID,
       headers: {
           "Client-ID": clientId,
           "Accept": "application/vnd.twitchtv.v3+json"
@@ -49,7 +49,7 @@ function getVODMeta(vodID, clientId, testServer) {
 
 function getChatFragment(start, vodID, testServer) {
   var options = {
-    url: getHost("https://rechat.twitch.tv", testServer)+"/rechat-messages?start="+start+"&video_id="+vodID,
+    url: getHost("https://rechat.twitch.tv", testServer)+"/rechat-messages?start="+start+"&video_id=v"+vodID,
     family: 4, // https://github.com/nodejs/node/issues/5436#issuecomment-189600282
   };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -91,7 +91,7 @@ function searchChat(start, length, vodID, c = false, progress = false, workerCou
             return result;
         };
         promises = promises.map((p) => {
-          return {then: () => { return p.then(progressListener); } };
+          return {then: (callback) => { return p.then(progressListener).then(callback); } };
         });
 	   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,6 +47,8 @@ function getVODMeta(vodID, clientId, testServer) {
     });
 }
 
+exports.getVODMeta = getVODMeta;
+
 function getChatFragment(start, vodID, testServer) {
   var options = {
     url: getHost("https://rechat.twitch.tv", testServer)+"/rechat-messages?start="+start+"&video_id=v"+vodID,

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
-const fetch = require("node-fetch"),
-    colors = require("colors"),
+const colors = require("colors"),
     toColors = require("hex-to-color-name"),
-    ProgressBar = require("progress");
+    ProgressBar = require("progress"),
+    requestpromise = require('request-promise');
 
 function colorize(string, hexColor) {
     return string[toColors(hexColor||"#FFFF00", {
@@ -28,36 +28,34 @@ function getHost(host, testServer) {
 }
 
 function getVODMeta(vodID, clientId, testServer) {
-    return fetch(getHost("https://api.twitch.tv", testServer)+"/kraken/videos/"+vodID, {
-        headers: {
-            "Client-ID": clientId,
-            "Accept": "application/vnd.twitchtv.v5+json"
-        }
-    }).then((resp) => {
-        if(resp.ok)
-            return resp.json();
-        else
-            throw "Could not load VOD details: " + resp.statusText;
-    }).then((json) => {
-        return {
-            start: Date.parse(json.recorded_at),
-            length: json.length
-        };
+    var options = {
+      url: getHost("https://api.twitch.tv", testServer)+"/kraken/videos/"+vodID,
+      headers: {
+          "Client-ID": clientId,
+          "Accept": "application/vnd.twitchtv.v3+json"
+      },
+      family: 4, // https://github.com/nodejs/node/issues/5436#issuecomment-189600282
+    };
+
+    return requestpromise(options).then((resp) => {
+      var json = JSON.parse(resp);
+
+      return {
+          start: Date.parse(json.recorded_at),
+          length: json.length
+      };
     });
 }
 
 function getChatFragment(start, vodID, testServer) {
-    return fetch(getHost("https://rechat.twitch.tv", testServer)+"/rechat-messages?start="+start+"&video_id="+vodID)
-    .then((resp) => {
-        if(resp.ok) {
-            return resp.json();
-        }
-        else {
-            throw "Could not load fragment at "+start+": "+resp.statusText;
-        }
-    }).then((json) => {
-        return json.data;
-    });
+  var options = {
+    url: getHost("https://rechat.twitch.tv", testServer)+"/rechat-messages?start="+start+"&video_id="+vodID,
+    family: 4, // https://github.com/nodejs/node/issues/5436#issuecomment-189600282
+  };
+
+  return requestpromise(options).then((resp) => {
+      return JSON.parse(resp).data;
+  });
 }
 
 function searchChat(start, length, vodID, c = false, progress = false, workerCount = 1, testServer) {

--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
   "devDependencies": {
     "ava": "^0.19.0",
     "codecov": "^2.0.1",
-    "eslint": "^3.14.0",
+    "eslint": "^4.2.0",
     "eslint-plugin-freaktechnik": "^2.0.0",
     "express": "^4.14.0",
-    "nyc": "^10.1.2"
+    "nyc": "^11.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
   "dependencies": {
     "colors": "^1.1.2",
     "hex-to-color-name": "^1.0.1",
-    "node-fetch": "^1.5.3",
     "progress": "^2.0.0",
+    "request": "^2.81.0",
+    "request-promise": "^4.2.1",
     "yargs": "^8.0.1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitch-chatlog",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Fetch the chat log to a Twitch VOD.",
   "main": "lib/index.js",
   "bin": {


### PR DESCRIPTION
The vodId GET argument passed to rechat.twitch.tv must have a v at the start of it. I have added the v to the two URLs.

Testing on mac, node-fetch would throw errors trying to use from both the command line or a node script including with require('twitch-chatlog')

With these changes, it will properly get through. Seems like an IPv4/IPv6 issue